### PR TITLE
Fix import 'signature' error

### DIFF
--- a/hackathonJuly27/lib/media.py
+++ b/hackathonJuly27/lib/media.py
@@ -2,7 +2,7 @@ import matplotlib
 import matplotlib.pyplot as plt
 
 from sklearn.metrics import precision_recall_curve
-from sklearn.utils.fixes import signature
+from funcsigs import signature
 
 def plot_pr_curve(y,yhat):
     precision,recall,_ = precision_recall_curve(y.ravel(), yhat.ravel())


### PR DESCRIPTION
Fixed the error cannot import name 'signature' from 'sklearn.utils.fixes' permanently without having to compromise on the ability to plot PR curves due to the deletion of plot_pr_curve function. Imported the signature from funcsigs.