### PR TITLE
Rectified errors in WAV_FLAC_Annotator_0_6.py

### DIFF
--- a/WAV_FLACprocessor_Val/AnnotateSpectrograms/WAV_FLAC_Annotator_0_6.py
+++ b/WAV_FLACprocessor_Val/AnnotateSpectrograms/WAV_FLAC_Annotator_0_6.py
@@ -92,7 +92,10 @@ spec = np.zeros([NfreqBins,NfftChunks])
 i=0
 maxSpec = 0;
 while idx < Ndata-Nsamples-1:
-    y = data[idx:idx+Nsamples][0:,1]  ####  Note Bene  here we extract the first channel of 1 -> N channels
+    if data.ndim == 1:
+        y = data[idx:idx+Nsamples]
+    else:
+        y = data[idx:idx+Nsamples][0:,1]  ####  Note Bene  here we extract the first channel of 1 -> N channels
     yf = fft(y)
     idx = idx+Nskip
 #    for j in range(0,5):

--- a/WAV_FLACprocessor_Val/AnnotateSpectrograms/WAV_FLAC_Annotator_0_6.py
+++ b/WAV_FLACprocessor_Val/AnnotateSpectrograms/WAV_FLAC_Annotator_0_6.py
@@ -16,6 +16,7 @@ WAV_Annotator  V 0.1
 
 """
 import matplotlib
+import soundfile as sf
 #matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 from matplotlib.widgets import RectangleSelector

--- a/WAV_FLACprocessor_Val/AnnotateSpectrograms/WAV_FLAC_Annotator_0_6.py
+++ b/WAV_FLACprocessor_Val/AnnotateSpectrograms/WAV_FLAC_Annotator_0_6.py
@@ -53,10 +53,10 @@ def toggle_selector(event):
     print(' Key pressed.', event.key)
     if event.key in ['Q', 'q'] and toggle_selector.RS.active:
         print('Rect selector deactivated')
-        toggle_selector.RS.active(False)
+        toggle_selector.RS.active = False
     if event.key in ['A', 'a'] and not toggle_selector.RS.active:
         print(' Rect selector activated')
-        toggle_selector.RS.active(True)
+        toggle_selector.RS.active = True
 
 ###########  Read in wav or flac file
 


### PR DESCRIPTION
Resolved errors in WAV_FLACprocessor_Val/AnnotateSpectrograms/WAV_FLAC_Annotator_0_6.py:
```
NameError: name 'sf' is not defined
```
and on using with single channel audio FLAC files,
```
IndexError: too many indices for array
```
and on exit,
```
TypeError: 'bool' object is not callable
```